### PR TITLE
Setup an event store within a Symfony app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2016-2020, Alexander Miertsch <kontakt@codeliner.ws>
+Copyright (c) 2016-2020, Sascha-Oliver Prolic
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of prooph nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "prooph/prooph-pack",
+    "description": "A pack to install Prooph PDO event store components in a Symfony Flex application",
+    "type": "symfony-pack",
+    "license": "BSD-3-Clause",
+    "keywords": ["event sourcing", "event store", "cqrs"],
+    "homepage": "http://getprooph.org/",
+    "authors": [
+        {
+            "name": "Alexander Miertsch",
+            "email": "contact@prooph.de",
+            "homepage": "http://www.prooph.de"
+        },
+        {
+            "name": "Sascha-Oliver Prolic",
+            "email": "saschaprolic@googlemail.com"
+        },
+        {
+            "name": "Oskar Pfeifer-Bley",
+            "email": "oskar@programming-php.net"
+        }
+    ],
+    "require": {
+        "doctrine/dbal": "^2.10",
+        "prooph/event-store-symfony-bundle": "^0.8.0",
+        "prooph/pdo-event-store": "^1.0"
+    }
+}


### PR DESCRIPTION
My current attempt of using Symfony recipes to setup an event store application is quite hard to maintain and reason about.

The first drawback I see is to spread the package configurations through many recipes, while they won't run correctly if all the packages are not required within the user's project.

For example, the recipe for the prooph/event-store-symfony-bundle package will fail if the prooph/pdo-event-store package is not required as well (the former is not requiring the latter).

2 years ago, I did an attempt to create a prooph pack with a full blown CQRS/ES Symfony app, but this lead to really poor developer experience in my opinion. In most cases, I had to remove a lot of extra boilerplate (I already had a working command bus in my app for instance), that's why I didn't release it.

This new attempt focuses on one and only one thing: setting up an event store relying on the `prooph/pdo-event-store` package.

If this is accepted, I will basically merge/remove the prooph recipes on [symfony/recipes-contrib](https://github.com/symfony/recipes-contrib/):

![Screenshot from 2020-01-23 15-59-02](https://user-images.githubusercontent.com/668604/72995507-562a8680-3df9-11ea-8ba2-b3fce0972752.png)
