### PR TITLE
Provides barebone pdo event store lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "prooph/prooph-pack",
-    "description": "A pack to install Prooph PDO event store components in a Symfony Flex application",
+    "description": "A pack for the Prooph PDO event store",
     "type": "symfony-pack",
     "license": "BSD-3-Clause",
     "keywords": ["event sourcing", "event store", "cqrs"],
@@ -22,7 +22,6 @@
     ],
     "require": {
         "doctrine/dbal": "^2.10",
-        "prooph/event-store-symfony-bundle": "^0.8.0",
         "prooph/pdo-event-store": "^1.0"
     }
 }


### PR DESCRIPTION
There are a few solutions to preconfigure a Prooph PDO event store within a Symfony app.

## Barebone
One might manually configure the event-store (the "interop" factories could even be used, but that would require a few changes in their implementation, especially since they rely on a "config" service within the container, which does not exist in Symfony, I guess this is some ZF convention).
This is the solution provided in this pull request.
It focuses on one and only one thing: preconfiguring a PDO event store.

## Bundle-based
One might let the bundle do the service definition itself, and take a more declarative approach.
I haven't found the bundle EOL on the [Prooph annoucement](https://www.sasaprolic.com/2018/08/the-future-of-prooph-components.html). Does it mean that the bundle will be maintained and its usage should be promoted?

# Blueprints

From my experience, the [`prooph/event-sourcing`](https://github.com/prooph/event-sourcing/) is really useful, writing by yourself these classes is tedious but the package is meant to be abandonned (thus, it's probably not a good idea to require it from the pack). However, AFAIU, the strategy here is to provide blueprints, which could be done by the Symfony Flex Recipe.

For instance, once I have an Event Store instance, I don't like to use it directly from one of my aggregate repository. Instead, I prefer to wrap it within an [`AggregateRepository`](https://github.com/prooph/event-sourcing/blob/master/src/Aggregate/AggregateRepository.php) which will take care of many things (like extracting events, converting it to array, enriching metadata, upserting, ...). 

I'd like to gather some Symfony/Prooph user experience before going any further. Do you prefer configuring yourself the event store service, or do you use the bundle? If you're not using the bundle, why not? Could it be resolved by improving it somehow, or is it simply a personal preference?

# Recipe
FYI, the `symfony/recipes-contrib` branch I'm working on is [here](https://github.com/gquemener/recipes-contrib/pull/1)